### PR TITLE
Fixing .tv expiration regex

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -183,5 +183,6 @@ expdays=$((diffseconds/86400))
 [ $expdays -lt $warning ] && die $STATE_WARNING "WARNING - Domain $domain will expire in $expdays days ($expdate)."
 
 # No alarms? Ok, everything is right.
-echo "OK - Domain $domain will expire in $expdays days ($expdate)."
+echo "OK - Domain $domain will expire in $expdays days ($expdate)." 
+echo "$domain $expdays" >> tlds.txt
 exit $STATE_OK


### PR DESCRIPTION
New reply for .tv domain expiration.
Expiration Date: 2017-01-26T10:14:11Z (old)
Registrar Registration Expiration Date: 2017-01-26 (new?)
