### PR TITLE
Fixed .im TLD, however regexp could be a bit better

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -109,6 +109,7 @@ expiration=$(
 		DATE_YYYY_MM_DD_DASH = "[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]"
 		DATE_YYYY_MM_DD_DOT = "[0-9][0-9][0-9][0-9]\.[0-9][0-9]\.[0-9][0-9]"
 		DATE_YYYY_MM_DD_SLASH = "[0-9][0-9][0-9][0-9]/[0-9][0-9]/[0-9][0-9]"
+		DATE_DD_MM_YYYY_SLASH = "[0-9][0-9]"
 		# Wed Mar 02 23:59:59 GMT 2016
 		DATE_DAY_MON_DD_HHMMSS_TZ_YYYY = "[A-Z][a-z][a-z] [A-Z][a-z][a-z] [0-9][0-9] " HH_MM_DD " GMT " YYYY
 		# 02-May-2018 16:12:25 UTC
@@ -181,6 +182,8 @@ expiration=$(
 
 	# Expiry date: 2017/07/16
 	/Expiry date:/ && $NF ~ DATE_YYYY_MM_DD_SLASH {split($3, a, "/"); printf("%s-%s-%s", a[1], a[2], a[3]); exit}
+	# Expiry Date: 19/11/2015 00:59:58
+	/Expiry Date:/ && $NF ~ DATE_DD_MM_YYYY_SLASH {split($3, a, "/"); printf("%s-%s-%s", a[3], a[2], a[1]); exit}
 
 	# Expires: 2014-01-31
 	# Expiry : 2014-03-08

--- a/test.sh
+++ b/test.sh
@@ -17,6 +17,7 @@ isnic.is
 mail.ru
 phonedot.mobi
 trashmail.se
+trashmail.im
 "
 
 whois=$(pwd)/whois.sh


### PR DESCRIPTION
Added support for .IM domains.
Its strange that awk or the code seems to have a problem with the regexp:
DATE_DD_MM_YYYY_SLASH = "[0-9][0-9]\/[0-9][0-9]\/[0-9][0-9][0-9][0-9]"

So I used:
DATE_DD_MM_YYYY_SLASH = "[0-9][0-9]"
