### PR TITLE
More robust utils.sh sourcing

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -19,8 +19,21 @@ set -e
 PROGRAM=${0##*/}
 VERSION=1.5.0
 PROGPATH=${0%/*}
+
+# try to source ./utils.sh first and if that doesn't exist try
+#	/usr/lib/nagios/plugins/utils.sh
+if [ -x "$PROGPATH/utils.sh" ];
+then
+	UTILSPATH="$PROGPATH/utils.sh"
+elif [ -x /usr/lib/nagios/plugins/utils.sh ];
+then
+	UTILSPATH="/usr/lib/nagios/plugins/utils.sh"
+else
+	die 3 "Can't source utils.sh"
+fi
+
 # shellcheck source=/dev/null
-. "$PROGPATH/utils.sh"
+. "$UTILSPATH"
 
 die() {
 	local rc="$1"


### PR DESCRIPTION
Please check the commit message for details.

We need this because we don't deploy third-party scripts directly to the default location of `/usr/lib/nagios/plugins`.

Thought it made sense to push upstream, considering that it doesn't break current behaviour and the likeliness of other users hitting the same issue.