### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,6 @@ addons:
     - dash
     - bash
 
-before_install:
-  # Grab ShellCheck from the Debian repo
-  # install shellcheck after other packages already installed from Ubuntu repo
-  # https://github.com/koalaman/shellcheck/issues/941
-  - curl -sSL "https://ftp-master.debian.org/keys/archive-key-7.0.asc" | sudo -E apt-key add -
-  - echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" | sudo tee -a /etc/apt/sources.list > /dev/null
-  - sudo apt-get update
-  - sudo apt-get install shellcheck
-
 matrix:
   fast_finish: true
 


### PR DESCRIPTION
shellcheck is already installed now on Travis CI as per https://github.com/koalaman/shellcheck/wiki/TravisCI