### PR TITLE
Fix handling when whois returns 1 on some Verisign domains

### DIFF
--- a/check_domain.sh
+++ b/check_domain.sh
@@ -228,6 +228,9 @@ run_whois() {
 	if grep -q -e "fgets: Connection reset by peer" "$outfile"; then
 		error=0
 	fi
+	if grep -q -e "Registry Domain ID: .*VRSN" "$outfile"; then
+		error=0
+	fi
 
 	[ $error -eq 0 ] || die "$STATE_UNKNOWN" "UNKNOWN - WHOIS exited with error $error."
 }

--- a/domains
+++ b/domains
@@ -64,3 +64,4 @@ yubico.sg
 yubikey.sg
 yubico.fi
 yubikey.fi
+vetomies.com


### PR DESCRIPTION
Some Verisign domains make certain versions of  whois return 1. 
This change greps the output for Registry Domain ID related to Verisign and ignores the false error code.